### PR TITLE
Add GoRouter navigation and splash screen

### DIFF
--- a/lib/auth/forgot_password_screen.dart
+++ b/lib/auth/forgot_password_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'bloc/auth_bloc.dart';
 import 'bloc/auth_event.dart';
 import 'bloc/auth_state.dart';
@@ -50,9 +51,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                       : const Text('Send reset link'),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
+                  onPressed: () => context.pop(),
                   child: const Text('Back to login'),
                 ),
               ],

--- a/lib/auth/login_screen.dart
+++ b/lib/auth/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'bloc/auth_bloc.dart';
 import 'bloc/auth_event.dart';
 import 'bloc/auth_state.dart';
@@ -24,6 +25,7 @@ class _LoginScreenState extends State<LoginScreen> {
           if (state is AuthSuccess) {
             ScaffoldMessenger.of(context)
                 .showSnackBar(SnackBar(content: Text(state.message)));
+            context.go('/home');
           } else if (state is AuthFailure) {
             ScaffoldMessenger.of(context)
                 .showSnackBar(SnackBar(content: Text(state.error)));
@@ -60,15 +62,11 @@ class _LoginScreenState extends State<LoginScreen> {
                       : const Text('Login'),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.pushNamed(context, '/signup');
-                  },
+                  onPressed: () => context.go('/signup'),
                   child: const Text('Create account'),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.pushNamed(context, '/forgot');
-                  },
+                  onPressed: () => context.go('/forgot'),
                   child: const Text('Forgot password?'),
                 ),
               ],

--- a/lib/auth/signup_screen.dart
+++ b/lib/auth/signup_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'bloc/auth_bloc.dart';
 import 'bloc/auth_event.dart';
 import 'bloc/auth_state.dart';
@@ -60,9 +61,7 @@ class _SignupScreenState extends State<SignupScreen> {
                       : const Text('Sign Up'),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
+                  onPressed: () => context.pop(),
                   child: const Text('Back to login'),
                 ),
               ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'auth/login_screen.dart';
 import 'auth/signup_screen.dart';
 import 'auth/forgot_password_screen.dart';
 import 'auth/bloc/auth_bloc.dart';
+import 'screens/splash_screen.dart';
+import 'screens/walkthrough_screen.dart';
+import 'screens/home_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,21 +16,28 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
+  static final _router = GoRouter(
+    routes: [
+      GoRoute(path: '/', builder: (_) => const SplashScreen()),
+      GoRoute(path: '/walkthrough', builder: (_) => const WalkthroughScreen()),
+      GoRoute(path: '/login', builder: (_) => const LoginScreen()),
+      GoRoute(path: '/signup', builder: (_) => const SignupScreen()),
+      GoRoute(path: '/forgot', builder: (_) => const ForgotPasswordScreen()),
+      GoRoute(path: '/home', builder: (_) => const HomeScreen()),
+    ],
+  );
+
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) => AuthBloc(),
-      child: MaterialApp(
+      child: MaterialApp.router(
         title: 'Bhook Lagi Hain',
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
           useMaterial3: true,
         ),
-        routes: {
-          '/signup': (_) => const SignupScreen(),
-          '/forgot': (_) => const ForgotPasswordScreen(),
-        },
-        home: const LoginScreen(),
+        routerConfig: _router,
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Home Screen')),
+    );
+  }
+}

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Timer(const Duration(seconds: 2), () {
+      context.go('/walkthrough');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text(
+          'Bhook Lagi Hain',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/walkthrough_screen.dart
+++ b/lib/screens/walkthrough_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class WalkthroughScreen extends StatelessWidget {
+  const WalkthroughScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Continue as:',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => context.go('/login'),
+              child: const Text('As a Customer'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => context.go('/login'),
+              child: const Text('As a Maid'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
 
   flutter_bloc: ^8.1.3
+  go_router: ^13.2.0
 
 
 


### PR DESCRIPTION
## Summary
- add `go_router` dependency
- create splash, walkthrough and home screens
- switch navigation to `GoRouter`
- update auth screens to use new routes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d208878f08331b3ccf03dc6fbe062