### PR TITLE
Add navigation and dio service

### DIFF
--- a/lib/api/auth_service.dart
+++ b/lib/api/auth_service.dart
@@ -1,0 +1,40 @@
+import 'package:dio/dio.dart';
+
+class AuthService {
+  AuthService({Dio? dio}) : _dio = dio ?? Dio(BaseOptions(baseUrl: 'https://example.com/api'));
+
+  final Dio _dio;
+
+  Future<String> login(String email, String password) async {
+    final response = await _dio.post('/login', data: {
+      'email': email,
+      'password': password,
+    });
+    return response.data['message'] as String? ?? 'Success';
+  }
+
+  Future<String> signup(String email, String password) async {
+    final response = await _dio.post('/signup', data: {
+      'email': email,
+      'password': password,
+    });
+    return response.data['message'] as String? ?? 'Success';
+  }
+
+  Future<String> resetPassword(String email) async {
+    final response = await _dio.post('/forgot', data: {
+      'email': email,
+    });
+    return response.data['message'] as String? ?? 'Success';
+  }
+
+  Future<String> logout() async {
+    final response = await _dio.post('/logout');
+    return response.data['message'] as String? ?? 'Success';
+  }
+
+  Future<String> deleteAccount() async {
+    final response = await _dio.delete('/delete');
+    return response.data['message'] as String? ?? 'Success';
+  }
+}

--- a/lib/auth/bloc/auth_bloc.dart
+++ b/lib/auth/bloc/auth_bloc.dart
@@ -1,41 +1,66 @@
 import 'package:bloc/bloc.dart';
 import 'auth_event.dart';
 import 'auth_state.dart';
+import '../../api/auth_service.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
-  AuthBloc() : super(AuthInitial()) {
+  AuthBloc(this._service) : super(AuthInitial()) {
     on<LoginRequested>(_onLogin);
     on<SignupRequested>(_onSignup);
     on<PasswordResetRequested>(_onReset);
+    on<LogoutRequested>(_onLogout);
+    on<DeleteAccountRequested>(_onDelete);
   }
+
+  final AuthService _service;
 
   Future<void> _onLogin(LoginRequested event, Emitter<AuthState> emit) async {
     emit(AuthLoading());
-    await Future.delayed(const Duration(seconds: 1));
-    if (event.email.isNotEmpty && event.password.isNotEmpty) {
-      emit(AuthSuccess('Logged in as ${event.email}'));
-    } else {
-      emit(AuthFailure('Email and password required'));
+    try {
+      final message = await _service.login(event.email, event.password);
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
     }
   }
 
   Future<void> _onSignup(SignupRequested event, Emitter<AuthState> emit) async {
     emit(AuthLoading());
-    await Future.delayed(const Duration(seconds: 1));
-    if (event.email.isNotEmpty && event.password.isNotEmpty) {
-      emit(AuthSuccess('Account created for ${event.email}'));
-    } else {
-      emit(AuthFailure('Email and password required'));
+    try {
+      final message = await _service.signup(event.email, event.password);
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
     }
   }
 
   Future<void> _onReset(PasswordResetRequested event, Emitter<AuthState> emit) async {
     emit(AuthLoading());
-    await Future.delayed(const Duration(seconds: 1));
-    if (event.email.isNotEmpty) {
-      emit(AuthSuccess('Password reset link sent to ${event.email}'));
-    } else {
-      emit(AuthFailure('Email required'));
+    try {
+      final message = await _service.resetPassword(event.email);
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onLogout(LogoutRequested event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final message = await _service.logout();
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onDelete(DeleteAccountRequested event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final message = await _service.deleteAccount();
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
     }
   }
 }

--- a/lib/auth/bloc/auth_event.dart
+++ b/lib/auth/bloc/auth_event.dart
@@ -16,3 +16,7 @@ class PasswordResetRequested extends AuthEvent {
   final String email;
   PasswordResetRequested(this.email);
 }
+
+class LogoutRequested extends AuthEvent {}
+
+class DeleteAccountRequested extends AuthEvent {}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'auth/login_screen.dart';
 import 'auth/signup_screen.dart';
 import 'auth/forgot_password_screen.dart';
 import 'auth/bloc/auth_bloc.dart';
+import 'api/auth_service.dart';
 import 'screens/splash_screen.dart';
 import 'screens/walkthrough_screen.dart';
 import 'screens/home_screen.dart';
@@ -30,7 +31,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => AuthBloc(),
+      create: (_) => AuthBloc(AuthService()),
       child: MaterialApp.router(
         title: 'Bhook Lagi Hain',
         theme: ThemeData(

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ExploreScreen extends StatelessWidget {
+  const ExploreScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Explore Screen'),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,12 +1,63 @@
 import 'package:flutter/material.dart';
+import 'explore_screen.dart';
+import 'settings_screen.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
   @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _selectedIndex = 0;
+
+  final _pages = const [
+    Center(child: Text('Home Screen')),
+    ExploreScreen(),
+    SettingsScreen(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Home Screen')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bhook Lagi Hain')),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: const [
+            DrawerHeader(
+              decoration: BoxDecoration(color: Colors.deepPurple),
+              child: Text('Menu', style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        ),
+      ),
+      body: _pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.explore),
+            label: 'Explore',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../auth/bloc/auth_bloc.dart';
+import '../auth/bloc/auth_event.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        ListTile(
+          title: const Text('Logout'),
+          leading: const Icon(Icons.logout),
+          onTap: () {
+            context.read<AuthBloc>().add(LogoutRequested());
+          },
+        ),
+        ListTile(
+          title: const Text('Delete Account'),
+          leading: const Icon(Icons.delete_forever),
+          onTap: () {
+            context.read<AuthBloc>().add(DeleteAccountRequested());
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
 
   flutter_bloc: ^8.1.3
   go_router: ^13.2.0
+  dio: ^5.4.1
 
 
 


### PR DESCRIPTION
## Summary
- add dio package
- create `AuthService` for API calls
- integrate `AuthService` into `AuthBloc`
- add logout and delete account events
- implement home screen with drawer and bottom navigation
- add explore and settings screens

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2351d61483318b154ac9dd8a1d5e