### PR TITLE
Add Firebase auth with Google, Facebook and phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Firebase Setup
+
+This project uses Firebase Authentication for email/password, Google, Facebook
+and phone login. To configure Firebase:
+
+1. Install the [FlutterFire CLI](https://firebase.flutter.dev/docs/cli/). 
+2. Run `flutterfire configure` inside the project to generate
+   `lib/firebase_options.dart` and configure your Android and iOS apps.
+3. Add the generated Firebase configuration files
+   (`google-services.json` for Android and `GoogleService-Info.plist` for iOS)
+   to the respective platforms.
+4. Enable **Email/Password**, **Google**, **Facebook** and **Phone** sign-in
+   providers in the Firebase console.
+5. After configuration run `flutter pub get` and launch the app.

--- a/lib/api/auth_service.dart
+++ b/lib/api/auth_service.dart
@@ -1,40 +1,69 @@
-import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 
 class AuthService {
-  AuthService({Dio? dio}) : _dio = dio ?? Dio(BaseOptions(baseUrl: 'https://example.com/api'));
-
-  final Dio _dio;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final GoogleSignIn _googleSignIn = GoogleSignIn();
+  final FacebookAuth _facebookAuth = FacebookAuth.instance;
 
   Future<String> login(String email, String password) async {
-    final response = await _dio.post('/login', data: {
-      'email': email,
-      'password': password,
-    });
-    return response.data['message'] as String? ?? 'Success';
+    await _auth.signInWithEmailAndPassword(email: email, password: password);
+    return 'Login successful';
   }
 
   Future<String> signup(String email, String password) async {
-    final response = await _dio.post('/signup', data: {
-      'email': email,
-      'password': password,
-    });
-    return response.data['message'] as String? ?? 'Success';
+    await _auth.createUserWithEmailAndPassword(email: email, password: password);
+    return 'Signup successful';
+  }
+
+  Future<String> loginWithGoogle() async {
+    final GoogleSignInAccount? account = await _googleSignIn.signIn();
+    if (account == null) {
+      throw Exception('Google sign in aborted');
+    }
+    final GoogleSignInAuthentication auth = await account.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: auth.accessToken,
+      idToken: auth.idToken,
+    );
+    await _auth.signInWithCredential(credential);
+    return 'Google sign in successful';
+  }
+
+  Future<String> loginWithFacebook() async {
+    final LoginResult result = await _facebookAuth.login();
+    if (result.status != LoginStatus.success) {
+      throw Exception('Facebook sign in failed');
+    }
+    final OAuthCredential credential =
+        FacebookAuthProvider.credential(result.accessToken!.token);
+    await _auth.signInWithCredential(credential);
+    return 'Facebook sign in successful';
+  }
+
+  Future<ConfirmationResult> loginWithPhone(String phoneNumber) {
+    return _auth.signInWithPhoneNumber(phoneNumber);
+  }
+
+  Future<String> verifyPhoneCode(
+      ConfirmationResult result, String smsCode) async {
+    await result.confirm(smsCode);
+    return 'Phone sign in successful';
   }
 
   Future<String> resetPassword(String email) async {
-    final response = await _dio.post('/forgot', data: {
-      'email': email,
-    });
-    return response.data['message'] as String? ?? 'Success';
+    await _auth.sendPasswordResetEmail(email: email);
+    return 'Reset email sent';
   }
 
   Future<String> logout() async {
-    final response = await _dio.post('/logout');
-    return response.data['message'] as String? ?? 'Success';
+    await _auth.signOut();
+    return 'Logged out';
   }
 
   Future<String> deleteAccount() async {
-    final response = await _dio.delete('/delete');
-    return response.data['message'] as String? ?? 'Success';
+    await _auth.currentUser?.delete();
+    return 'Account deleted';
   }
 }

--- a/lib/auth/bloc/auth_bloc.dart
+++ b/lib/auth/bloc/auth_bloc.dart
@@ -10,6 +10,10 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<PasswordResetRequested>(_onReset);
     on<LogoutRequested>(_onLogout);
     on<DeleteAccountRequested>(_onDelete);
+    on<GoogleLoginRequested>(_onGoogleLogin);
+    on<FacebookLoginRequested>(_onFacebookLogin);
+    on<PhoneLoginRequested>(_onPhoneLogin);
+    on<VerifyPhoneCodeRequested>(_onVerifyPhoneCode);
   }
 
   final AuthService _service;
@@ -58,6 +62,46 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     emit(AuthLoading());
     try {
       final message = await _service.deleteAccount();
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onGoogleLogin(GoogleLoginRequested event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final message = await _service.loginWithGoogle();
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onFacebookLogin(FacebookLoginRequested event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final message = await _service.loginWithFacebook();
+      emit(AuthSuccess(message));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onPhoneLogin(PhoneLoginRequested event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final result = await _service.loginWithPhone(event.phoneNumber);
+      emit(PhoneCodeSent(result));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onVerifyPhoneCode(VerifyPhoneCodeRequested event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final message = await _service.verifyPhoneCode(event.confirmationResult, event.smsCode);
       emit(AuthSuccess(message));
     } catch (e) {
       emit(AuthFailure(e.toString()));

--- a/lib/auth/bloc/auth_event.dart
+++ b/lib/auth/bloc/auth_event.dart
@@ -17,6 +17,21 @@ class PasswordResetRequested extends AuthEvent {
   PasswordResetRequested(this.email);
 }
 
+class GoogleLoginRequested extends AuthEvent {}
+
+class FacebookLoginRequested extends AuthEvent {}
+
+class PhoneLoginRequested extends AuthEvent {
+  final String phoneNumber;
+  PhoneLoginRequested(this.phoneNumber);
+}
+
+class VerifyPhoneCodeRequested extends AuthEvent {
+  final dynamic confirmationResult;
+  final String smsCode;
+  VerifyPhoneCodeRequested(this.confirmationResult, this.smsCode);
+}
+
 class LogoutRequested extends AuthEvent {}
 
 class DeleteAccountRequested extends AuthEvent {}

--- a/lib/auth/bloc/auth_state.dart
+++ b/lib/auth/bloc/auth_state.dart
@@ -13,3 +13,8 @@ class AuthFailure extends AuthState {
   final String error;
   AuthFailure(this.error);
 }
+
+class PhoneCodeSent extends AuthState {
+  final dynamic confirmationResult;
+  PhoneCodeSent(this.confirmationResult);
+}

--- a/lib/auth/login_screen.dart
+++ b/lib/auth/login_screen.dart
@@ -29,6 +29,8 @@ class _LoginScreenState extends State<LoginScreen> {
           } else if (state is AuthFailure) {
             ScaffoldMessenger.of(context)
                 .showSnackBar(SnackBar(content: Text(state.error)));
+          } else if (state is PhoneCodeSent) {
+            context.go('/otp', extra: state.confirmationResult);
           }
         },
         builder: (context, state) {
@@ -60,6 +62,22 @@ class _LoginScreenState extends State<LoginScreen> {
                   child: state is AuthLoading
                       ? const CircularProgressIndicator()
                       : const Text('Login'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    context.read<AuthBloc>().add(GoogleLoginRequested());
+                  },
+                  child: const Text('Login with Google'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    context.read<AuthBloc>().add(FacebookLoginRequested());
+                  },
+                  child: const Text('Login with Facebook'),
+                ),
+                ElevatedButton(
+                  onPressed: () => context.go('/phone'),
+                  child: const Text('Continue with phone'),
                 ),
                 TextButton(
                   onPressed: () => context.go('/signup'),

--- a/lib/auth/otp_screen.dart
+++ b/lib/auth/otp_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'bloc/auth_bloc.dart';
+import 'bloc/auth_event.dart';
+import 'bloc/auth_state.dart';
+
+class OtpScreen extends StatefulWidget {
+  final dynamic confirmationResult;
+  const OtpScreen({super.key, required this.confirmationResult});
+
+  @override
+  State<OtpScreen> createState() => _OtpScreenState();
+}
+
+class _OtpScreenState extends State<OtpScreen> {
+  final TextEditingController _codeController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verify OTP')),
+      body: BlocConsumer<AuthBloc, AuthState>(
+        listener: (context, state) {
+          if (state is AuthSuccess) {
+            ScaffoldMessenger.of(context)
+                .showSnackBar(SnackBar(content: Text(state.message)));
+            context.go('/home');
+          } else if (state is AuthFailure) {
+            ScaffoldMessenger.of(context)
+                .showSnackBar(SnackBar(content: Text(state.error)));
+          }
+        },
+        builder: (context, state) {
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextField(
+                  controller: _codeController,
+                  decoration: const InputDecoration(labelText: 'OTP code'),
+                ),
+                const SizedBox(height: 20),
+                ElevatedButton(
+                  onPressed: () {
+                    context.read<AuthBloc>().add(
+                        VerifyPhoneCodeRequested(
+                            widget.confirmationResult, _codeController.text));
+                  },
+                  child: state is AuthLoading
+                      ? const CircularProgressIndicator()
+                      : const Text('Verify'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/auth/phone_number_screen.dart
+++ b/lib/auth/phone_number_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'bloc/auth_bloc.dart';
+import 'bloc/auth_event.dart';
+import 'bloc/auth_state.dart';
+
+class PhoneNumberScreen extends StatefulWidget {
+  const PhoneNumberScreen({super.key});
+
+  @override
+  State<PhoneNumberScreen> createState() => _PhoneNumberScreenState();
+}
+
+class _PhoneNumberScreenState extends State<PhoneNumberScreen> {
+  final TextEditingController _phoneController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Phone Login')),
+      body: BlocConsumer<AuthBloc, AuthState>(
+        listener: (context, state) {
+          if (state is PhoneCodeSent) {
+            context.go('/otp', extra: state.confirmationResult);
+          } else if (state is AuthFailure) {
+            ScaffoldMessenger.of(context)
+                .showSnackBar(SnackBar(content: Text(state.error)));
+          }
+        },
+        builder: (context, state) {
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextField(
+                  controller: _phoneController,
+                  decoration: const InputDecoration(labelText: 'Phone number'),
+                ),
+                const SizedBox(height: 20),
+                ElevatedButton(
+                  onPressed: () {
+                    context
+                        .read<AuthBloc>()
+                        .add(PhoneLoginRequested(_phoneController.text));
+                  },
+                  child: state is AuthLoading
+                      ? const CircularProgressIndicator()
+                      : const Text('Send OTP'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,63 @@
+// TODO: Replace with your Firebase project configuration.
+// This file was generated via `flutterfire configure`.
+
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not configured for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'YOUR_API_KEY',
+    appId: 'YOUR_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    authDomain: 'YOUR_AUTH_DOMAIN',
+    storageBucket: 'YOUR_STORAGE_BUCKET',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'YOUR_API_KEY',
+    appId: 'YOUR_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_STORAGE_BUCKET',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'YOUR_API_KEY',
+    appId: 'YOUR_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_STORAGE_BUCKET',
+    iosClientId: 'YOUR_IOS_CLIENT_ID',
+    iosBundleId: 'com.example.bhookLagiHain',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'YOUR_API_KEY',
+    appId: 'YOUR_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_STORAGE_BUCKET',
+    iosClientId: 'YOUR_IOS_CLIENT_ID',
+    iosBundleId: 'com.example.bhookLagiHain',
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,13 +4,21 @@ import 'package:go_router/go_router.dart';
 import 'auth/login_screen.dart';
 import 'auth/signup_screen.dart';
 import 'auth/forgot_password_screen.dart';
+import 'auth/phone_number_screen.dart';
+import 'auth/otp_screen.dart';
 import 'auth/bloc/auth_bloc.dart';
 import 'api/auth_service.dart';
 import 'screens/splash_screen.dart';
 import 'screens/walkthrough_screen.dart';
 import 'screens/home_screen.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   runApp(const MyApp());
 }
 
@@ -24,6 +32,11 @@ class MyApp extends StatelessWidget {
       GoRoute(path: '/login', builder: (_, __) => const LoginScreen()),
       GoRoute(path: '/signup', builder: (_, __) => const SignupScreen()),
       GoRoute(path: '/forgot', builder: (_, __) => const ForgotPasswordScreen()),
+      GoRoute(path: '/phone', builder: (_, __) => const PhoneNumberScreen()),
+      GoRoute(
+        path: '/otp',
+        builder: (_, state) => OtpScreen(confirmationResult: state.extra),
+      ),
       GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
     ],
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,10 @@ dependencies:
   flutter_bloc: ^8.1.3
   go_router: ^13.2.0
   dio: ^5.4.1
+  firebase_core: ^2.31.0
+  firebase_auth: ^4.17.0
+  google_sign_in: ^6.2.1
+  flutter_facebook_auth: ^6.0.3
 
 
 


### PR DESCRIPTION
## Summary
- integrate Firebase Authentication and social providers
- add phone login screens and OTP verification
- display additional login options
- initialize Firebase in `main.dart`
- document Firebase setup steps

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2539a5508331b7c4bb9207e0c5f8