### PR TITLE
Improve auth screen design and navigation

### DIFF
--- a/lib/auth/login_screen.dart
+++ b/lib/auth/login_screen.dart
@@ -39,14 +39,26 @@ class _LoginScreenState extends State<LoginScreen> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
+                const Icon(
+                  Icons.login,
+                  size: 80,
+                  color: Colors.deepPurple,
+                ),
+                const SizedBox(height: 20),
                 TextField(
                   controller: _emailController,
-                  decoration: const InputDecoration(labelText: 'Email'),
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    prefixIcon: Icon(Icons.email),
+                  ),
                 ),
                 const SizedBox(height: 12),
                 TextField(
                   controller: _passwordController,
-                  decoration: const InputDecoration(labelText: 'Password'),
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    prefixIcon: Icon(Icons.lock),
+                  ),
                   obscureText: true,
                 ),
                 const SizedBox(height: 20),
@@ -80,11 +92,11 @@ class _LoginScreenState extends State<LoginScreen> {
                   child: const Text('Continue with phone'),
                 ),
                 TextButton(
-                  onPressed: () => context.go('/signup'),
+                  onPressed: () => context.push('/signup'),
                   child: const Text('Create account'),
                 ),
                 TextButton(
-                  onPressed: () => context.go('/forgot'),
+                  onPressed: () => context.push('/forgot'),
                   child: const Text('Forgot password?'),
                 ),
               ],

--- a/lib/auth/signup_screen.dart
+++ b/lib/auth/signup_screen.dart
@@ -36,14 +36,26 @@ class _SignupScreenState extends State<SignupScreen> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
+                const Icon(
+                  Icons.person_add,
+                  size: 80,
+                  color: Colors.deepPurple,
+                ),
+                const SizedBox(height: 20),
                 TextField(
                   controller: _emailController,
-                  decoration: const InputDecoration(labelText: 'Email'),
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    prefixIcon: Icon(Icons.email),
+                  ),
                 ),
                 const SizedBox(height: 12),
                 TextField(
                   controller: _passwordController,
-                  decoration: const InputDecoration(labelText: 'Password'),
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    prefixIcon: Icon(Icons.lock),
+                  ),
                   obscureText: true,
                 ),
                 const SizedBox(height: 20),
@@ -61,7 +73,13 @@ class _SignupScreenState extends State<SignupScreen> {
                       : const Text('Sign Up'),
                 ),
                 TextButton(
-                  onPressed: () => context.pop(),
+                  onPressed: () {
+                    if (context.canPop()) {
+                      context.pop();
+                    } else {
+                      context.go('/login');
+                    }
+                  },
                   child: const Text('Back to login'),
                 ),
               ],


### PR DESCRIPTION
## Summary
- Add visual icons and better styling to Login and Signup screens
- Fix navigation by using push and safe Back to login handling

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b530e797088331b177dd06a6e3c62e