### PR TITLE
Add terms, privacy, and help info screens with shared state management

### DIFF
--- a/lib/info/info_cubit.dart
+++ b/lib/info/info_cubit.dart
@@ -1,0 +1,32 @@
+import 'package:bloc/bloc.dart';
+import 'info_state.dart';
+
+enum InfoPage { terms, privacy, help }
+
+class InfoCubit extends Cubit<InfoState> {
+  InfoCubit() : super(const InfoState());
+
+  Future<void> load(InfoPage page) async {
+    emit(state.copyWith(loading: true, content: null, error: null));
+    try {
+      await Future.delayed(const Duration(milliseconds: 300));
+      final content = _contentForPage(page);
+      emit(InfoState(content: content));
+    } catch (e) {
+      emit(InfoState(error: e.toString()));
+    }
+  }
+
+  String _contentForPage(InfoPage page) {
+    switch (page) {
+      case InfoPage.terms:
+        return 'These are the terms and conditions of the app.'
+            ' Users must agree to them before continuing.';
+      case InfoPage.privacy:
+        return 'This privacy policy explains how user data is handled'
+            ' and stored securely.';
+      case InfoPage.help:
+        return 'For help, please contact support or consult the FAQ section.';
+    }
+  }
+}

--- a/lib/info/info_state.dart
+++ b/lib/info/info_state.dart
@@ -1,0 +1,15 @@
+class InfoState {
+  final bool loading;
+  final String? content;
+  final String? error;
+
+  const InfoState({this.loading = false, this.content, this.error});
+
+  InfoState copyWith({bool? loading, String? content, String? error}) {
+    return InfoState(
+      loading: loading ?? this.loading,
+      content: content ?? this.content,
+      error: error ?? this.error,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,8 @@ import 'api/auth_service.dart';
 import 'screens/splash_screen.dart';
 import 'screens/walkthrough_screen.dart';
 import 'screens/home_screen.dart';
+import 'screens/info_screen.dart';
+import 'info/info_cubit.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 
@@ -38,6 +40,9 @@ class MyApp extends StatelessWidget {
         builder: (_, state) => OtpScreen(confirmationResult: state.extra),
       ),
       GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
+      GoRoute(path: '/terms', builder: (_, __) => const InfoScreen(page: InfoPage.terms)),
+      GoRoute(path: '/privacy', builder: (_, __) => const InfoScreen(page: InfoPage.privacy)),
+      GoRoute(path: '/help', builder: (_, __) => const InfoScreen(page: InfoPage.help)),
     ],
   );
 

--- a/lib/screens/info_screen.dart
+++ b/lib/screens/info_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../info/info_cubit.dart';
+import '../info/info_state.dart';
+
+class InfoScreen extends StatelessWidget {
+  final InfoPage page;
+  const InfoScreen({super.key, required this.page});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => InfoCubit()..load(page),
+      child: Scaffold(
+        appBar: AppBar(title: Text(_titleForPage(page))),
+        body: BlocBuilder<InfoCubit, InfoState>(
+          builder: (context, state) {
+            if (state.loading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (state.error != null) {
+              return Center(child: Text(state.error!));
+            }
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Text(state.content ?? ''),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  String _titleForPage(InfoPage page) {
+    switch (page) {
+      case InfoPage.terms:
+        return 'Terms & Conditions';
+      case InfoPage.privacy:
+        return 'Privacy Policy';
+      case InfoPage.help:
+        return 'Help';
+    }
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../auth/bloc/auth_bloc.dart';
 import '../auth/bloc/auth_event.dart';
+import 'package:go_router/go_router.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -11,6 +12,21 @@ class SettingsScreen extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
+        ListTile(
+          title: const Text('Terms & Conditions'),
+          leading: const Icon(Icons.description),
+          onTap: () => context.go('/terms'),
+        ),
+        ListTile(
+          title: const Text('Privacy Policy'),
+          leading: const Icon(Icons.privacy_tip),
+          onTap: () => context.go('/privacy'),
+        ),
+        ListTile(
+          title: const Text('Help'),
+          leading: const Icon(Icons.help_outline),
+          onTap: () => context.go('/help'),
+        ),
         ListTile(
           title: const Text('Logout'),
           leading: const Icon(Icons.logout),


### PR DESCRIPTION
## Summary
- Create reusable InfoScreen and InfoCubit for terms, privacy, and help content
- Add routes and navigation entries for legal and help pages
- Link settings menu to new informational screens

## Testing
- ⚠️ `flutter test` (failed: command not found)
- ⚠️ `apt-get update` (failed: repository 403 - no access)


------
https://chatgpt.com/codex/tasks/task_e_68b5379806448331ab7926503afa102a