### PR TITLE
Refactor router and improve settings navigation

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,0 +1,36 @@
+import 'package:go_router/go_router.dart';
+import 'auth/login_screen.dart';
+import 'auth/signup_screen.dart';
+import 'auth/forgot_password_screen.dart';
+import 'auth/phone_number_screen.dart';
+import 'auth/otp_screen.dart';
+import 'screens/splash_screen.dart';
+import 'screens/walkthrough_screen.dart';
+import 'screens/home_screen.dart';
+import 'screens/terms_screen.dart';
+import 'screens/privacy_screen.dart';
+import 'screens/help_screen.dart';
+
+class AppRouter {
+  AppRouter._();
+
+  static final GoRouter router = GoRouter(
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => const SplashScreen()),
+      GoRoute(path: '/walkthrough', builder: (_, __) => const WalkthroughScreen()),
+      GoRoute(path: '/login', builder: (_, __) => const LoginScreen()),
+      GoRoute(path: '/signup', builder: (_, __) => const SignupScreen()),
+      GoRoute(path: '/forgot', builder: (_, __) => const ForgotPasswordScreen()),
+      GoRoute(path: '/phone', builder: (_, __) => const PhoneNumberScreen()),
+      GoRoute(
+        path: '/otp',
+        builder: (_, state) => OtpScreen(confirmationResult: state.extra),
+      ),
+      GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
+      GoRoute(path: '/terms', builder: (_, __) => const TermsScreen()),
+      GoRoute(path: '/privacy', builder: (_, __) => const PrivacyScreen()),
+      GoRoute(path: '/help', builder: (_, __) => const HelpScreen()),
+    ],
+  );
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
-import 'auth/login_screen.dart';
-import 'auth/signup_screen.dart';
-import 'auth/forgot_password_screen.dart';
-import 'auth/phone_number_screen.dart';
-import 'auth/otp_screen.dart';
 import 'auth/bloc/auth_bloc.dart';
 import 'api/auth_service.dart';
-import 'screens/splash_screen.dart';
-import 'screens/walkthrough_screen.dart';
-import 'screens/home_screen.dart';
-import 'screens/terms_screen.dart';
-import 'screens/privacy_screen.dart';
-import 'screens/help_screen.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
+import 'app_router.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -28,25 +17,6 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  static final _router = GoRouter(
-    routes: [
-      GoRoute(path: '/', builder: (_, __) => const SplashScreen()),
-      GoRoute(path: '/walkthrough', builder: (_, __) => const WalkthroughScreen()),
-      GoRoute(path: '/login', builder: (_, __) => const LoginScreen()),
-      GoRoute(path: '/signup', builder: (_, __) => const SignupScreen()),
-      GoRoute(path: '/forgot', builder: (_, __) => const ForgotPasswordScreen()),
-      GoRoute(path: '/phone', builder: (_, __) => const PhoneNumberScreen()),
-      GoRoute(
-        path: '/otp',
-        builder: (_, state) => OtpScreen(confirmationResult: state.extra),
-      ),
-      GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
-      GoRoute(path: '/terms', builder: (_, __) => const TermsScreen()),
-      GoRoute(path: '/privacy', builder: (_, __) => const PrivacyScreen()),
-      GoRoute(path: '/help', builder: (_, __) => const HelpScreen()),
-    ],
-  );
-
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
@@ -58,7 +28,7 @@ class MyApp extends StatelessWidget {
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
           useMaterial3: true,
         ),
-        routerConfig: _router,
+        routerConfig: AppRouter.router,
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -15,17 +15,17 @@ class SettingsScreen extends StatelessWidget {
         ListTile(
           title: const Text('Terms & Conditions'),
           leading: const Icon(Icons.description),
-          onTap: () => context.go('/terms'),
+          onTap: () => context.push('/terms'),
         ),
         ListTile(
           title: const Text('Privacy Policy'),
           leading: const Icon(Icons.privacy_tip),
-          onTap: () => context.go('/privacy'),
+          onTap: () => context.push('/privacy'),
         ),
         ListTile(
           title: const Text('Help'),
           leading: const Icon(Icons.help_outline),
-          onTap: () => context.go('/help'),
+          onTap: () => context.push('/help'),
         ),
         ListTile(
           title: const Text('Logout'),


### PR DESCRIPTION
## Summary
- move GoRouter setup to new `AppRouter` class
- simplify `main.dart` to use centralized router
- use `context.push` for Terms, Privacy, and Help so back navigation works

## Testing
- `flutter format lib/main.dart lib/app_router.dart lib/screens/settings_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b53c7cebfc8331bb49b05c07145745