### PR TITLE
Fix back navigation for info links

### DIFF
--- a/lib/screens/walkthrough_screen.dart
+++ b/lib/screens/walkthrough_screen.dart
@@ -171,17 +171,17 @@ class _WalkthroughScreenState extends State<WalkthroughScreen>
                                   children: [
                                     _LinkText(
                                       label: 'Privacy Policy',
-                                      onTap: () => context.go('/privacy'),
+                                      onTap: () => context.push('/privacy'),
                                     ),
                                     _Dot(),
                                     _LinkText(
                                       label: 'Terms',
-                                      onTap: () => context.go('/terms'),
+                                      onTap: () => context.push('/terms'),
                                     ),
                                     _Dot(),
                                     _LinkText(
                                       label: 'Help',
-                                      onTap: () => context.go('/help'),
+                                      onTap: () => context.push('/help'),
                                     ),
                                   ],
                                 ),


### PR DESCRIPTION
## Summary
- ensure privacy, terms, and help links on the walkthrough use `push` so users can navigate back without exiting

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b53d5e78b88331bdfe6b87df0ec1d8