### PR TITLE
Integrate role-based login/signup API with Dio

### DIFF
--- a/lib/api/auth_service.dart
+++ b/lib/api/auth_service.dart
@@ -1,20 +1,38 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
+import 'package:dio/dio.dart';
 
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final GoogleSignIn _googleSignIn = GoogleSignIn();
   final FacebookAuth _facebookAuth = FacebookAuth.instance;
+  final Dio _dio = Dio(BaseOptions(baseUrl: 'http://localhost:3000/api'));
 
-  Future<String> login(String email, String password) async {
-    await _auth.signInWithEmailAndPassword(email: email, password: password);
-    return 'Login successful';
+  Future<String> login(String email, String password, String? role) async {
+    final path = role != null ? '/login/$role' : '/login';
+    try {
+      final res = await _dio.post(path, data: {
+        'email': email,
+        'password': password,
+      });
+      return res.data['message'] ?? 'Login successful';
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? 'Login failed');
+    }
   }
 
-  Future<String> signup(String email, String password) async {
-    await _auth.createUserWithEmailAndPassword(email: email, password: password);
-    return 'Signup successful';
+  Future<String> signup(String email, String password, String? role) async {
+    final path = role != null ? '/signup/$role' : '/signup';
+    try {
+      final res = await _dio.post(path, data: {
+        'email': email,
+        'password': password,
+      });
+      return res.data['message'] ?? 'Signup successful';
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? 'Signup failed');
+    }
   }
 
   Future<String> loginWithGoogle() async {

--- a/lib/auth/bloc/auth_bloc.dart
+++ b/lib/auth/bloc/auth_bloc.dart
@@ -21,7 +21,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   Future<void> _onLogin(LoginRequested event, Emitter<AuthState> emit) async {
     emit(AuthLoading());
     try {
-      final message = await _service.login(event.email, event.password);
+      final message =
+          await _service.login(event.email, event.password, event.role);
       emit(AuthSuccess(message));
     } catch (e) {
       emit(AuthFailure(e.toString()));
@@ -31,7 +32,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   Future<void> _onSignup(SignupRequested event, Emitter<AuthState> emit) async {
     emit(AuthLoading());
     try {
-      final message = await _service.signup(event.email, event.password);
+      final message =
+          await _service.signup(event.email, event.password, event.role);
       emit(AuthSuccess(message));
     } catch (e) {
       emit(AuthFailure(e.toString()));

--- a/lib/auth/bloc/auth_event.dart
+++ b/lib/auth/bloc/auth_event.dart
@@ -3,13 +3,15 @@ abstract class AuthEvent {}
 class LoginRequested extends AuthEvent {
   final String email;
   final String password;
-  LoginRequested(this.email, this.password);
+  final String? role;
+  LoginRequested(this.email, this.password, this.role);
 }
 
 class SignupRequested extends AuthEvent {
   final String email;
   final String password;
-  SignupRequested(this.email, this.password);
+  final String? role;
+  SignupRequested(this.email, this.password, this.role);
 }
 
 class PasswordResetRequested extends AuthEvent {

--- a/lib/auth/login_screen.dart
+++ b/lib/auth/login_screen.dart
@@ -47,11 +47,11 @@ class _LoginScreenState extends State<LoginScreen>
     super.dispose();
   }
 
-  void _submit(BuildContext context) {
+  void _submit(BuildContext context, String? role) {
     if (!(_formKey.currentState?.validate() ?? false)) return;
     HapticFeedback.lightImpact();
     context.read<AuthBloc>().add(
-      LoginRequested(_email.text.trim(), _password.text),
+      LoginRequested(_email.text.trim(), _password.text, role),
     );
   }
 
@@ -251,7 +251,7 @@ class _LoginScreenState extends State<LoginScreen>
                                         return null;
                                       },
                                       onSubmitted: (_) =>
-                                          _submit(context),
+                                          _submit(context, role),
                                     ),
 
                                     const SizedBox(height: 8),
@@ -326,7 +326,7 @@ class _LoginScreenState extends State<LoginScreen>
                                         label: 'Sign in',
                                         onPressed: loading
                                             ? null
-                                            : () => _submit(context),
+                                            : () => _submit(context, role),
                                       ),
                                     ),
 
@@ -465,8 +465,8 @@ class _LoginScreenState extends State<LoginScreen>
                                             ),
                                             onPressed: loading
                                                 ? null
-                                                : () => context
-                                                .push('/signup'),
+                                                : () => context.push(
+                                                    '/signup${role != null ? '?role=$role' : ''}'),
                                             child: const Text(
                                               'Create account',
                                               style: TextStyle(

--- a/lib/auth/signup_screen.dart
+++ b/lib/auth/signup_screen.dart
@@ -51,7 +51,7 @@ class _SignupScreenState extends State<SignupScreen>
     super.dispose();
   }
 
-  void _submit(BuildContext context) {
+  void _submit(BuildContext context, String? role) {
     if (!(_formKey.currentState?.validate() ?? false)) return;
     if (!_agree) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -61,7 +61,7 @@ class _SignupScreenState extends State<SignupScreen>
     }
     HapticFeedback.lightImpact();
     context.read<AuthBloc>().add(
-      SignupRequested(_email.text.trim(), _password.text),
+      SignupRequested(_email.text.trim(), _password.text, role),
     );
   }
 
@@ -317,7 +317,7 @@ class _SignupScreenState extends State<SignupScreen>
                                           }
                                           return null;
                                         },
-                                        onSubmitted: (_) => _submit(context),
+                                        onSubmitted: (_) => _submit(context, role),
                                       ),
 
                                       const SizedBox(height: 10),
@@ -385,7 +385,7 @@ class _SignupScreenState extends State<SignupScreen>
                                           loading: loading,
                                           onPressed: loading
                                               ? null
-                                              : () => _submit(context),
+                                              : () => _submit(context, role),
                                         ),
                                       ),
 
@@ -434,7 +434,8 @@ class _SignupScreenState extends State<SignupScreen>
                                             if (context.canPop()) {
                                               context.pop();
                                             } else {
-                                              context.go('/login');
+                                              context.go(
+                                                  '/login${role != null ? '?role=$role' : ''}');
                                             }
                                           },
                                           icon: const Icon(


### PR DESCRIPTION
## Summary
- Send role to authentication events and use Dio-based login/signup API calls
- Pass selected role through login/signup screens and preserve in navigation

## Testing
- `dart format lib/auth/bloc/auth_event.dart lib/auth/bloc/auth_bloc.dart lib/api/auth_service.dart lib/auth/login_screen.dart lib/auth/signup_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b677f22ccc8331be57ba16e5f9a57e